### PR TITLE
Terminar el control de driver BLE para shutdown

### DIFF
--- a/components/ble_driver/ble_common.c
+++ b/components/ble_driver/ble_common.c
@@ -17,16 +17,17 @@ const uint8_t char_property_read_write_notify = ESP_GATT_CHAR_PROP_BIT_WRITE | E
 const EventBits_t INACTIVE_BIT = ( 1 << 0 );
 const EventBits_t INITIALIZING_BIT = ( 1 << 1 );
 const EventBits_t INITIALIZED_BIT = ( 1 << 2 );
-const EventBits_t ADVERTISING_BIT = ( 1 << 3 );
-const EventBits_t PAIRING_BIT = ( 1 << 4 );
-const EventBits_t PAIRED_BIT = ( 1 << 5 );
-const EventBits_t RECORD_SYNCHRONIZED_BIT = ( 1 << 6 );
-const EventBits_t SHUTTING_DOWN_BIT = ( 1 << 7 );
-const EventBits_t SHUT_DOWN_BIT = ( 1 << 8 );
+const EventBits_t ENABLED_BIT = ( 1 << 3 );
+const EventBits_t ADVERTISING_BIT = ( 1 << 4 );
+const EventBits_t PAIRING_BIT = ( 1 << 5 );
+const EventBits_t PAIRED_BIT = ( 1 << 6 );
+const EventBits_t RECORD_SYNCHRONIZED_BIT = ( 1 << 7 );
+const EventBits_t SHUTTING_DOWN_BIT = ( 1 << 8 );
+const EventBits_t SHUT_DOWN_BIT = ( 1 << 9 );
 
 const EventBits_t ALL_BITS = (
-    INACTIVE | INITIALIZING_BIT | INITIALIZED_BIT | ADVERTISING_BIT | 
-    PAIRING_BIT | PAIRED_BIT | RECORD_SYNCHRONIZED_BIT | 
+    INACTIVE | INITIALIZING_BIT | INITIALIZED_BIT | ENABLED_BIT | 
+    ADVERTISING_BIT | PAIRING_BIT | PAIRED_BIT | RECORD_SYNCHRONIZED_BIT | 
     SHUTTING_DOWN_BIT | SHUT_DOWN_BIT
 );
 

--- a/components/ble_driver/include/ble_common.h
+++ b/components/ble_driver/include/ble_common.h
@@ -14,6 +14,7 @@ typedef enum {
     INACTIVE,
     INITIALIZING,
     INITIALIZED,
+    ENABLED,
     ADVERTISING,
     PAIRING,
     PAIRED,
@@ -38,6 +39,7 @@ extern const uint8_t char_property_read_write_notify;
 extern const EventBits_t INACTIVE_BIT;
 extern const EventBits_t INITIALIZING_BIT;
 extern const EventBits_t INITIALIZED_BIT;
+extern const EventBits_t ENABLED_BIT;
 extern const EventBits_t ADVERTISING_BIT;
 extern const EventBits_t PAIRING_BIT;
 extern const EventBits_t PAIRED_BIT;

--- a/components/ble_driver/include/ble_driver.h
+++ b/components/ble_driver/include/ble_driver.h
@@ -22,11 +22,11 @@
  * @brief Inicializa el driver BLE con sus perfiles GAP y GATT, para luego
  * comenzar el advertising.
  */ 
-esp_err_t ble_driver_init(const char* device_name);
+esp_err_t ble_driver_init(void);
 
-esp_err_t ble_driver_enable(void);
+esp_err_t ble_driver_enable(const char* device_name);
 
-esp_err_t ble_driver_sleep(void);
+esp_err_t ble_driver_start_advertising(void);
 
 esp_err_t ble_disconnect(void);
 
@@ -36,11 +36,11 @@ esp_err_t ble_driver_shutdown(void);
 
 esp_err_t ble_driver_deinit(void);
 
+esp_err_t ble_driver_sleep(void);
+
 esp_err_t ble_sync_battery_charge(uint8_t remaining_battery_charge);
 
 esp_err_t ble_synchronize_hydration_record(const hydration_record_t* record, const uint32_t sync_timeout_ms);
-
-uint32_t ble_get_advertising_start_ms(void);
 
 /**
  * @brief Esperar a que el status de la conexion BLE sea igual a status.

--- a/components/hydrate_common/hydrate_common.c
+++ b/components/hydrate_common/hydrate_common.c
@@ -28,7 +28,7 @@ static const uint16_t max_volume_delta_ml = 250;
 
 static const int32_t lifted_raw_weight = 25000;
 
-static const int64_t hydration_cooldown_ms = 3000;
+static const int64_t hydration_cooldown_ms = 2000;
 
 static int64_t latest_hydration_timestamp_ms = 0;
 


### PR DESCRIPTION
La funcionalidad de activación y desactivación de modo advertising del driver de BLE está implementada, para que el flujo de light sleep y deep sleep sea el correcto.